### PR TITLE
Add `for_source_only` property to sendMessage payload.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -16,6 +16,7 @@ async function sendMessage(
     broadcaster_id: broadcasterId,
     sender_id: senderId,
     message,
+    for_source_only: false,
   };
   return await fetch("https://api.twitch.tv/helix/chat/messages", {
     method: "POST",


### PR DESCRIPTION
The default behaviour will be changed on 19th of May. By than this change has to be implemented and tested.

https://discuss.dev.twitch.com/t/adding-for-source-only-parameter-for-shared-chat-and-a-behavior-update-for-send-chat-message-api-endpoint-may-19-2025/63261