### PR TITLE
Throw on missing env vars

### DIFF
--- a/get-account-access.ts
+++ b/get-account-access.ts
@@ -1,6 +1,7 @@
-import { getUser as getUserImpl } from "./utils.ts";
+import { checkEnv, getUser as getUserImpl } from "./utils.ts";
 
 async function getUser(access_token: string, login: string | null) {
+  checkEnv();
   return await getUserImpl(
     Deno.env.get("TWITCH_CLIENT_ID")!,
     access_token,
@@ -9,6 +10,7 @@ async function getUser(access_token: string, login: string | null) {
 }
 
 export default async function getAccountAccess(chatter: boolean) {
+  checkEnv();
   let scopes: string;
   if (chatter) {
     scopes = encodeURIComponent(["user:write:chat", "user:bot"].join(" "));

--- a/get-user-by-name.ts
+++ b/get-user-by-name.ts
@@ -1,6 +1,7 @@
-import { getUser as getUserImpl } from "./utils.ts";
+import { checkEnv, getUser as getUserImpl } from "./utils.ts";
 
 async function getUser(access_token: string, login: string | null) {
+  checkEnv();
   return await getUserImpl(
     Deno.env.get("TWITCH_CLIENT_ID")!,
     access_token,
@@ -9,6 +10,7 @@ async function getUser(access_token: string, login: string | null) {
 }
 
 async function getToken() {
+  checkEnv();
   const clientCredentials = await fetch(
     `https://id.twitch.tv/oauth2/token?client_id=${
       Deno.env.get("TWITCH_CLIENT_ID")
@@ -32,6 +34,7 @@ async function getToken() {
 }
 
 async function handle() {
+  checkEnv();
   const user = prompt("Enter the User whose Data you want to retrieve: ");
   if (!user) {
     // Probably cancelled prompt, I guess

--- a/utils.ts
+++ b/utils.ts
@@ -1,3 +1,15 @@
+export function checkEnv() {
+  if (hasEnv) return;
+  throw new Deno.errors.InvalidData(
+    "TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET env vars are required",
+  );
+}
+
+export function hasEnv() {
+  return Deno.env.has("TWITCH_CLIENT_ID") &&
+    Deno.env.has("TWITCH_CLIENT_SECRET");
+}
+
 export async function getUser(
   clientId: string,
   accessToken: string,

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,5 @@
 export function checkEnv() {
-  if (hasEnv) return;
+  if (hasEnv()) return;
   throw new Deno.errors.InvalidData(
     "TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET env vars are required",
   );


### PR DESCRIPTION
This fixes deno getting hung if the env vars are not given, for example when forgetting `--env` cli option.